### PR TITLE
Adds support for declaring the tls connector builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate tokio_service;
 extern crate tokio_tls;
 
 pub use client::HttpsConnector;
+pub use client::TlsConnectorBuilder;
 pub use stream::MaybeHttpsStream;
 
 mod client;


### PR DESCRIPTION
The tls connector builder is used to create a tls instance.
By making the tls connector builder configurable, the user gets access to modify
the root certificate and other options.

I'm open to improve this implementation.

Solves: #3