### PR TITLE
Re-export the Error struct from native_tls

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use futures::{Future, Poll};
 use hyper::client::{Connect, HttpConnector};
 use hyper::Uri;
 use native_tls::TlsConnector;
+pub use native_tls::Error;
 use tokio_core::reactor::Handle;
 use tokio_service::Service;
 use tokio_tls::TlsConnectorExt;
@@ -28,7 +29,7 @@ impl HttpsConnector<HttpConnector> {
     ///
     /// This uses hyper's default `HttpConnector`, and default `TlsConnector`.
     /// If you wish to use something besides the defaults, use `From::from`.
-    pub fn new(threads: usize, handle: &Handle) -> ::native_tls::Result<Self> {
+    pub fn new(threads: usize, handle: &Handle) -> Result<Self, Error> {
         let mut http = HttpConnector::new(threads, handle);
         http.enforce_http(false);
         let tls = TlsConnector::builder()?.build()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate tokio_io;
 extern crate tokio_service;
 extern crate tokio_tls;
 
-pub use client::{HttpsConnector, HttpsConnecting};
+pub use client::{HttpsConnector, HttpsConnecting, Error};
 pub use stream::MaybeHttpsStream;
 
 mod client;


### PR DESCRIPTION
If one needs to express the `Error` type in a function signature or similar then one must also depend on the `native_tls` crate. This is a bit burdensome IMO. If this crate just re-exports the error it uses it becomes more ergonomic to use, at least in the way I use this library.