### PR TITLE
Update to Hyper v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/hyper-tls"
 [dependencies]
 futures = "0.1.21"
 native-tls = "0.1"
-hyper = { git = "https://github.com/hyperium/hyper" }
+hyper = "0.12"
 tokio-io = "0.1"
 tokio-tls = { version = "0.1.4", default-features = false }
 


### PR DESCRIPTION
Looks like 0.12 is published for Hyper, so this repo can probably point to the official one rather than Git?