### PR TITLE
add openssl `vendored` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ homepage = "https://hyper.rs"
 repository = "https://github.com/hyperium/hyper-tls"
 documentation = "https://docs.rs/hyper-tls"
 
+[features]
+vendored = ["native-tls/vendored"]
+
 [dependencies]
 bytes = "0.4"
 futures = "0.1.21"


### PR DESCRIPTION
Adds the possibility to enable the `vendored` feature of openssl.
Before, `native-tls` had to be included as a dependency if this feature was needed.