### PR TITLE
Update native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "0.4"
 futures = "0.1.21"
-native-tls = "0.2"
+native-tls = "0.2.1"
 hyper = "0.12"
 tokio-io = "0.1"
 


### PR DESCRIPTION
hyper-tls (and by proxy hyper itself) uses old rust-openssl  library that causes issues with openssl 1.1.1 (https://github.com/sfackler/rust-openssl/issues/994). You've added support for inline openssl compilation [here](https://github.com/hyperium/hyper-tls/commit/dc8a13409b753ce212aada925ad5edb58e185349), but it was added in 0.2.1 and this crate uses 0.2, so this change didn't change anything afaik.