### PR TITLE
Update to tokio alpha 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 native-tls = "0.2"
 hyper = "=0.13.0-alpha.1"
-tokio-io = "=0.2.0-alpha.4"
-tokio-tls = "=0.3.0-alpha.4"
+tokio-io = "=0.2.0-alpha.5"
+tokio-tls = "=0.3.0-alpha.5"
 
 [dev-dependencies]
-tokio = "=0.2.0-alpha.4"
+tokio = "=0.2.0-alpha.5"


### PR DESCRIPTION
This allows the crate to be used with the latest master of hyper again.