### PR TITLE
Fix HttpsConnector::new() documentation (DNS)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), hyper::Error>{
-//!     // 4 is number of blocking DNS threads
 //!     let https = HttpsConnector::new().unwrap();
 //!     let client = Client::builder().build::<_, hyper::Body>(https);
 //!


### PR DESCRIPTION
Remove comment in `HttpsConnector::new()`'s documentation regarding the
number of threads to use in blocking DNS requests.