### PR TITLE
Typed errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,9 @@ pub enum HttpsConnectorError<E: Send> {
     HttpConnector(E),
     /// `native_tls` failed when setting up a TLS connection.
     NativeTls(native_tls::Error),
+
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<E: Send + std::fmt::Debug> std::fmt::Debug for HttpsConnectorError<E> {
@@ -22,6 +25,7 @@ impl<E: Send + std::fmt::Debug> std::fmt::Debug for HttpsConnectorError<E> {
                 .debug_tuple("HttpsConnectorError::NativeTls")
                 .field(err)
                 .finish(),
+            HttpsConnectorError::__Nonexhaustive => unimplemented!(),
         }
     }
 }
@@ -34,6 +38,7 @@ impl<E: Send + std::fmt::Display> std::fmt::Display for HttpsConnectorError<E> {
             }
             HttpsConnectorError::HttpConnector(err) => write!(f, "http connector error: {}", err),
             HttpsConnectorError::NativeTls(err) => write!(f, "native tls error: {}", err),
+            HttpsConnectorError::__Nonexhaustive => unimplemented!(),
         }
     }
 }
@@ -44,6 +49,7 @@ impl<E: Send + std::error::Error + 'static> std::error::Error for HttpsConnector
             HttpsConnectorError::ForceHttpsButUriNotHttps => None,
             HttpsConnectorError::HttpConnector(err) => Some(err),
             HttpsConnectorError::NativeTls(err) => Some(err),
+            HttpsConnectorError::__Nonexhaustive => unimplemented!(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,45 @@
+/// ConnectorError represents a HttpsConnector error.
+pub enum ConnectorError<E: Send> {
+    /// An https:// URI was provided when the force_https option was on.
+    ForceHttpsButUriNotHttps,
+    /// Underlying HttpConnector failed when setting up an HTTP connection.
+    HttpConnector(E),
+    /// `native_tls` failed when setting up a TLS connection.
+    NativeTls(native_tls::Error),
+}
+
+impl<E: Send + std::fmt::Debug> std::fmt::Debug for ConnectorError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectorError::ForceHttpsButUriNotHttps => {
+                write!(f, "ConnectorError::ForceHttpsButUriNotHttps")
+            }
+            ConnectorError::HttpConnector(err) => {
+                write!(f, "ConnectorError::HttpConnector({:?})", err)
+            }
+            ConnectorError::NativeTls(err) => write!(f, "ConnectorError::NativeTls({:?})", err),
+        }
+    }
+}
+
+impl<E: Send + std::fmt::Display> std::fmt::Display for ConnectorError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectorError::ForceHttpsButUriNotHttps => {
+                write!(f, "https required but URI was not https")
+            }
+            ConnectorError::HttpConnector(err) => write!(f, "http connector error: {}", err),
+            ConnectorError::NativeTls(err) => write!(f, "native tls error: {}", err),
+        }
+    }
+}
+
+impl<E: Send + std::error::Error + 'static> std::error::Error for ConnectorError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ConnectorError::ForceHttpsButUriNotHttps => None,
+            ConnectorError::HttpConnector(err) => Some(err),
+            ConnectorError::NativeTls(err) => Some(err),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,14 +12,16 @@ impl<E: Send + std::fmt::Debug> std::fmt::Debug for HttpsConnectorError<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             HttpsConnectorError::ForceHttpsButUriNotHttps => {
-                write!(f, "HttpsConnectorError::ForceHttpsButUriNotHttps")
+                f.write_str("HttpsConnectorError::ForceHttpsButUriNotHttps")
             }
-            HttpsConnectorError::HttpConnector(err) => {
-                write!(f, "HttpsConnectorError::HttpConnector({:?})", err)
-            }
-            HttpsConnectorError::NativeTls(err) => {
-                write!(f, "HttpsConnectorError::NativeTls({:?})", err)
-            }
+            HttpsConnectorError::HttpConnector(err) => f
+                .debug_tuple("HttpsConnectorError::HttpConnector")
+                .field(err)
+                .finish(),
+            HttpsConnectorError::NativeTls(err) => f
+                .debug_tuple("HttpsConnectorError::NativeTls")
+                .field(err)
+                .finish(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-/// ConnectorError represents a HttpsConnector error.
-pub enum ConnectorError<E: Send> {
+/// HttpsConnectorError represents a HttpsConnector error.
+pub enum HttpsConnectorError<E: Send> {
     /// An https:// URI was provided when the force_https option was on.
     ForceHttpsButUriNotHttps,
     /// Underlying HttpConnector failed when setting up an HTTP connection.
@@ -8,38 +8,40 @@ pub enum ConnectorError<E: Send> {
     NativeTls(native_tls::Error),
 }
 
-impl<E: Send + std::fmt::Debug> std::fmt::Debug for ConnectorError<E> {
+impl<E: Send + std::fmt::Debug> std::fmt::Debug for HttpsConnectorError<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConnectorError::ForceHttpsButUriNotHttps => {
-                write!(f, "ConnectorError::ForceHttpsButUriNotHttps")
+            HttpsConnectorError::ForceHttpsButUriNotHttps => {
+                write!(f, "HttpsConnectorError::ForceHttpsButUriNotHttps")
             }
-            ConnectorError::HttpConnector(err) => {
-                write!(f, "ConnectorError::HttpConnector({:?})", err)
+            HttpsConnectorError::HttpConnector(err) => {
+                write!(f, "HttpsConnectorError::HttpConnector({:?})", err)
             }
-            ConnectorError::NativeTls(err) => write!(f, "ConnectorError::NativeTls({:?})", err),
+            HttpsConnectorError::NativeTls(err) => {
+                write!(f, "HttpsConnectorError::NativeTls({:?})", err)
+            }
         }
     }
 }
 
-impl<E: Send + std::fmt::Display> std::fmt::Display for ConnectorError<E> {
+impl<E: Send + std::fmt::Display> std::fmt::Display for HttpsConnectorError<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConnectorError::ForceHttpsButUriNotHttps => {
+            HttpsConnectorError::ForceHttpsButUriNotHttps => {
                 write!(f, "https required but URI was not https")
             }
-            ConnectorError::HttpConnector(err) => write!(f, "http connector error: {}", err),
-            ConnectorError::NativeTls(err) => write!(f, "native tls error: {}", err),
+            HttpsConnectorError::HttpConnector(err) => write!(f, "http connector error: {}", err),
+            HttpsConnectorError::NativeTls(err) => write!(f, "native tls error: {}", err),
         }
     }
 }
 
-impl<E: Send + std::error::Error + 'static> std::error::Error for ConnectorError<E> {
+impl<E: Send + std::error::Error + 'static> std::error::Error for HttpsConnectorError<E> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            ConnectorError::ForceHttpsButUriNotHttps => None,
-            ConnectorError::HttpConnector(err) => Some(err),
-            ConnectorError::NativeTls(err) => Some(err),
+            HttpsConnectorError::ForceHttpsButUriNotHttps => None,
+            HttpsConnectorError::HttpConnector(err) => Some(err),
+            HttpsConnectorError::NativeTls(err) => Some(err),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,9 @@
 pub extern crate native_tls;
 
 pub use client::{HttpsConnecting, HttpsConnector};
+pub use error::HttpsConnectorError;
 pub use stream::{MaybeHttpsStream, TlsStream};
-pub use error::ConnectorError;
 
 mod client;
-mod stream;
 mod error;
+mod stream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub extern crate native_tls;
 
 pub use client::{HttpsConnecting, HttpsConnector};
 pub use stream::{MaybeHttpsStream, TlsStream};
+pub use error::ConnectorError;
 
 mod client;
 mod stream;
+mod error;


### PR DESCRIPTION
Closes #57 

If you want to know what errors to expect - this is the best way.
Properly utilizes `Error::source` to expose error cause.

The interface I implemented is a bit different: it's more permissive and therefore accepts more error types.
It also exposes the `ForceHttpsButUriNotHttps` properly so that it can be handled (which I have to do since I have `force_https` set to `true`).