### PR TITLE
Remove brackets of IPv6 literals

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -125,7 +125,7 @@ where
             return err(ForceHttpsButUriNotHttps.into());
         }
 
-        let host = dst.host().unwrap_or("").to_owned();
+        let host = dst.host().unwrap_or("").trim_matches(|c| c == '[' || c == ']').to_owned();
         let connecting = self.http.call(dst);
         let tls = self.tls.clone();
         let fut = async move {


### PR DESCRIPTION
This addresses #68. It turns out we only need to remove the brackets from IPv6 literals, the TLS library handles the zero compression and suppression part.