### PR TITLE
Revert "Upgrade to `tokio-native-tls` (#65)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytes = "0.5"
 native-tls = "0.2"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
 tokio = { version = "0.2" }
-tokio-native-tls = "0.1"
+tokio-tls = "0.3"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["io-std", "macros"] }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll};
 use bytes::{Buf, BufMut};
 use hyper::client::connect::{Connected, Connection};
 use tokio::io::{AsyncRead, AsyncWrite};
-pub use tokio_native_tls::TlsStream;
+pub use tokio_tls::TlsStream;
 
 /// A stream that might be protected with TLS.
 pub enum MaybeHttpsStream<T> {
@@ -119,7 +119,7 @@ impl<T: AsyncRead + AsyncWrite + Connection + Unpin> Connection for MaybeHttpsSt
     fn connected(&self) -> Connected {
         match self {
             MaybeHttpsStream::Http(s) => s.connected(),
-            MaybeHttpsStream::Https(s) => s.get_ref().get_ref().get_ref().connected(),
+            MaybeHttpsStream::Https(s) => s.get_ref().connected(),
         }
     }
 }


### PR DESCRIPTION
This reverts commit 7c9adcdebba980ed3d3a6190480fafe37628264e.