### PR TITLE
Add possibility to set the SNI host for the connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-tls"
-version = "0.4.3" # don't forget html_root_url in lib.rs
+version = "0.4.4" # don't forget html_root_url in lib.rs
 description = "Default TLS implementation for use with hyper"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!     Ok(())
 //! }
 //! ```
-#![doc(html_root_url = "https://docs.rs/hyper-tls/0.4.3")]
+#![doc(html_root_url = "https://docs.rs/hyper-tls/0.4.4")]
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
Sometimes the URI  and the exact host which we want to connect have different domains. And we need to have a way to set the domain for the TLS connection which will be used to verify the TLS cert.
The domain from the URI will still be used to create a underlying TCP connection.

For example:

Target host: example.com
Target host's TLS: example.net

with setting the SNI host to `example.net` we can still easily connect to `example.com` and get the correct resources as for `example.net`