### PR TITLE
Bump tokio from 0.2 to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "0.5"
 native-tls = "0.2"
-hyper = { version = "0.13", default-features = false, features = ["tcp"] }
+hyper = { git = "https://github.com/hyperium/hyper.git", default-features = false, features = ["tcp"] }
 tokio = { version = "0.3" }
 tokio-native-tls = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ vendored = ["native-tls/vendored"]
 bytes = "0.5"
 native-tls = "0.2"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-tokio = { version = "0.2" }
-tokio-tls = "0.3"
+tokio = { version = "0.3" }
+tokio-native-tls = "0.2"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["io-std", "macros"] }
+tokio = { version = "0.3", features = ["full"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 
 use hyper::{client::connect::HttpConnector, service::Service, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_tls::TlsConnector;
+use tokio_native_tls::TlsConnector;
 
 use crate::stream::MaybeHttpsStream;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,10 +3,9 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use bytes::{Buf, BufMut};
 use hyper::client::connect::{Connected, Connection};
-use tokio::io::{AsyncRead, AsyncWrite};
-pub use tokio_tls::TlsStream;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+pub use tokio_native_tls::TlsStream;
 
 /// A stream that might be protected with TLS.
 pub enum MaybeHttpsStream<T> {
@@ -41,34 +40,14 @@ impl<T> From<TlsStream<T>> for MaybeHttpsStream<T> {
 
 impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for MaybeHttpsStream<T> {
     #[inline]
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [std::mem::MaybeUninit<u8>]) -> bool {
-        match self {
-            MaybeHttpsStream::Http(s) => s.prepare_uninitialized_buffer(buf),
-            MaybeHttpsStream::Https(s) => s.prepare_uninitialized_buffer(buf),
-        }
-    }
-
-    #[inline]
     fn poll_read(
         self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize, io::Error>> {
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         match Pin::get_mut(self) {
             MaybeHttpsStream::Http(s) => Pin::new(s).poll_read(cx, buf),
             MaybeHttpsStream::Https(s) => Pin::new(s).poll_read(cx, buf),
-        }
-    }
-
-    #[inline]
-    fn poll_read_buf<B: BufMut>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<Result<usize, io::Error>> {
-        match Pin::get_mut(self) {
-            MaybeHttpsStream::Http(s) => Pin::new(s).poll_read_buf(cx, buf),
-            MaybeHttpsStream::Https(s) => Pin::new(s).poll_read_buf(cx, buf),
         }
     }
 }
@@ -83,18 +62,6 @@ impl<T: AsyncWrite + AsyncRead + Unpin> AsyncWrite for MaybeHttpsStream<T> {
         match Pin::get_mut(self) {
             MaybeHttpsStream::Http(s) => Pin::new(s).poll_write(cx, buf),
             MaybeHttpsStream::Https(s) => Pin::new(s).poll_write(cx, buf),
-        }
-    }
-
-    #[inline]
-    fn poll_write_buf<B: Buf>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<Result<usize, io::Error>> {
-        match Pin::get_mut(self) {
-            MaybeHttpsStream::Http(s) => Pin::new(s).poll_write_buf(cx, buf),
-            MaybeHttpsStream::Https(s) => Pin::new(s).poll_write_buf(cx, buf),
         }
     }
 
@@ -119,7 +86,7 @@ impl<T: AsyncRead + AsyncWrite + Connection + Unpin> Connection for MaybeHttpsSt
     fn connected(&self) -> Connected {
         match self {
             MaybeHttpsStream::Http(s) => s.connected(),
-            MaybeHttpsStream::Https(s) => s.get_ref().connected(),
+            MaybeHttpsStream::Https(s) => s.get_ref().get_ref().get_ref().connected(),
         }
     }
 }


### PR DESCRIPTION
# Changes
* `Cargo.toml`
    * bump `tokio` from `0.2` to `0.3`
    * exchange `tokio-tls` with `tokio-native-tls 0.2`
* `stream`:
    * adapt `impl AsyncRead for MaybeHttpsStream`
    * adapt `impl AsyncWrite for MaybeHttpsStream`
    * adapt `impl Connection for MaybeHttpsStream`

Fixes #76 

# Status
- [x] The examples still need to be adapted, but for that we require `hyper` to support `tokio 0.3` → implemented in https://github.com/hyperium/hyper/pull/2319
    - [ ] `hyper` release including changes