### PR TITLE
Upgrade to Tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ tokio = "1.0.0"
 tokio-native-tls = "0.3.0"
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["io-std", "macros"] }
+tokio = { version = "1.0.0", features = ["io-std", "macros", "io-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "1.0.0"
 native-tls = "0.2.6"
-hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http1"] }
+hyper = { version = "0.14.2", default-features = false, features = ["tcp", "client"] }
 tokio = "1.0.0"
 tokio-native-tls = "0.3.0"
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["io-std", "macros", "io-util"] }
+hyper = { version = "0.14.2", default-features = false, features = ["http1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "1.0.0"
 native-tls = "0.2.6"
-hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http1", "http2"] }
+hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http1"] }
 tokio = "1.0.0"
 tokio-native-tls = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2018"
 vendored = ["native-tls/vendored"]
 
 [dependencies]
-bytes = "1.0.0"
-native-tls = "0.2.6"
+bytes = "1"
+native-tls = "0.2.1"
 hyper = { version = "0.14.2", default-features = false, features = ["tcp", "client"] }
-tokio = "1.0.0"
-tokio-native-tls = "0.3.0"
+tokio = "1"
+tokio-native-tls = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["io-std", "macros", "io-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ edition = "2018"
 vendored = ["native-tls/vendored"]
 
 [dependencies]
-bytes = "0.5"
-native-tls = "0.2"
-hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-tokio = { version = "0.2" }
-tokio-tls = "0.3"
+bytes = "1.0.0"
+native-tls = "0.2.6"
+hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http1", "http2"] }
+tokio = "1.0.0"
+tokio-native-tls = "0.2.0"
+
+[patch.crates-io]
+tokio-native-tls = { git = "https://github.com/tokio-rs/tls.git", rev = "44e978cfa6e46294c0e352fad820456dbe94bdaa" }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["io-std", "macros"] }
+tokio = { version = "1.0.0", features = ["io-std", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,7 @@ bytes = "1.0.0"
 native-tls = "0.2.6"
 hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http1", "http2"] }
 tokio = "1.0.0"
-tokio-native-tls = "0.2.0"
-
-[patch.crates-io]
-tokio-native-tls = { git = "https://github.com/tokio-rs/tls.git", rev = "44e978cfa6e46294c0e352fad820456dbe94bdaa" }
+tokio-native-tls = "0.3.0"
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["io-std", "macros"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,9 +1,8 @@
-
-use hyper::{Client, body::HttpBody as _};
+use hyper::{body::HttpBody as _, Client};
 use hyper_tls::HttpsConnector;
 use tokio::io::{self, AsyncWriteExt as _};
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let https = HttpsConnector::new();
     let client = Client::builder().build::<_, hyper::Body>(https);
@@ -15,9 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     while let Some(chunk) = res.body_mut().data().await {
         let chunk = chunk?;
-        io::stdout()
-            .write_all(&chunk)
-            .await?
+        io::stdout().write_all(&chunk).await?
     }
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 
 use hyper::{client::connect::HttpConnector, service::Service, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_tls::TlsConnector;
+use tokio_native_tls::TlsConnector;
 
 use crate::stream::MaybeHttpsStream;
 
@@ -65,13 +65,18 @@ impl<T> HttpsConnector<T> {
     pub fn https_only(&mut self, enable: bool) {
         self.force_https = enable;
     }
-    
+
     /// With connector constructor
-    /// 
+    ///
     pub fn new_with_connector(http: T) -> Self {
         native_tls::TlsConnector::new()
             .map(|tls| HttpsConnector::from((http, tls.into())))
-            .unwrap_or_else(|e| panic!("HttpsConnector::new_with_connector(<connector>) failure: {}", e))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "HttpsConnector::new_with_connector(<connector>) failure: {}",
+                    e
+                )
+            })
     }
 }
 
@@ -120,15 +125,17 @@ where
             return err(ForceHttpsButUriNotHttps.into());
         }
 
-        let host = dst.host().unwrap_or("").trim_matches(|c| c == '[' || c == ']').to_owned();
+        let host = dst
+            .host()
+            .unwrap_or("")
+            .trim_matches(|c| c == '[' || c == ']')
+            .to_owned();
         let connecting = self.http.call(dst);
         let tls = self.tls.clone();
         let fut = async move {
             let tcp = connecting.await.map_err(Into::into)?;
             let maybe = if is_https {
-                let tls = tls
-                    .connect(&host, tcp)
-                    .await?;
+                let tls = tls.connect(&host, tcp).await?;
                 MaybeHttpsStream::Https(tls)
             } else {
                 MaybeHttpsStream::Http(tcp)
@@ -143,8 +150,7 @@ fn err<T>(e: BoxError) -> HttpsConnecting<T> {
     HttpsConnecting(Box::pin(async { Err(e) }))
 }
 
-type BoxedFut<T> =
-    Pin<Box<dyn Future<Output = Result<MaybeHttpsStream<T>, BoxError>> + Send>>;
+type BoxedFut<T> = Pin<Box<dyn Future<Output = Result<MaybeHttpsStream<T>, BoxError>> + Send>>;
 
 /// A Future representing work to connect to a URL, and a TLS handshake.
 pub struct HttpsConnecting<T>(BoxedFut<T>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! use hyper_tls::HttpsConnector;
 //! use hyper::Client;
 //!
-//! #[tokio::main]
+//! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>>{
 //!     let https = HttpsConnector::new();
 //!     let client = Client::builder().build::<_, hyper::Body>(https);

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,12 +1,12 @@
 use std::fmt;
 use std::io;
+use std::io::IoSlice;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use bytes::{Buf, BufMut};
 use hyper::client::connect::{Connected, Connection};
-use tokio::io::{AsyncRead, AsyncWrite};
-pub use tokio_tls::TlsStream;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+pub use tokio_native_tls::TlsStream;
 
 /// A stream that might be protected with TLS.
 pub enum MaybeHttpsStream<T> {
@@ -41,34 +41,14 @@ impl<T> From<TlsStream<T>> for MaybeHttpsStream<T> {
 
 impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for MaybeHttpsStream<T> {
     #[inline]
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [std::mem::MaybeUninit<u8>]) -> bool {
-        match self {
-            MaybeHttpsStream::Http(s) => s.prepare_uninitialized_buffer(buf),
-            MaybeHttpsStream::Https(s) => s.prepare_uninitialized_buffer(buf),
-        }
-    }
-
-    #[inline]
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize, io::Error>> {
+        buf: &mut ReadBuf,
+    ) -> Poll<Result<(), io::Error>> {
         match Pin::get_mut(self) {
             MaybeHttpsStream::Http(s) => Pin::new(s).poll_read(cx, buf),
             MaybeHttpsStream::Https(s) => Pin::new(s).poll_read(cx, buf),
-        }
-    }
-
-    #[inline]
-    fn poll_read_buf<B: BufMut>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<Result<usize, io::Error>> {
-        match Pin::get_mut(self) {
-            MaybeHttpsStream::Http(s) => Pin::new(s).poll_read_buf(cx, buf),
-            MaybeHttpsStream::Https(s) => Pin::new(s).poll_read_buf(cx, buf),
         }
     }
 }
@@ -86,15 +66,21 @@ impl<T: AsyncWrite + AsyncRead + Unpin> AsyncWrite for MaybeHttpsStream<T> {
         }
     }
 
-    #[inline]
-    fn poll_write_buf<B: Buf>(
+    fn poll_write_vectored(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut B,
+        bufs: &[IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
         match Pin::get_mut(self) {
-            MaybeHttpsStream::Http(s) => Pin::new(s).poll_write_buf(cx, buf),
-            MaybeHttpsStream::Https(s) => Pin::new(s).poll_write_buf(cx, buf),
+            MaybeHttpsStream::Http(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            MaybeHttpsStream::Https(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            MaybeHttpsStream::Http(s) => s.is_write_vectored(),
+            MaybeHttpsStream::Https(s) => s.is_write_vectored(),
         }
     }
 
@@ -119,7 +105,7 @@ impl<T: AsyncRead + AsyncWrite + Connection + Unpin> Connection for MaybeHttpsSt
     fn connected(&self) -> Connected {
         match self {
             MaybeHttpsStream::Http(s) => s.connected(),
-            MaybeHttpsStream::Https(s) => s.get_ref().connected(),
+            MaybeHttpsStream::Https(s) => s.get_ref().get_ref().get_ref().connected(),
         }
     }
 }


### PR DESCRIPTION
Currently pulling in tokio-native-tls via a git dependency, since https://github.com/tokio-rs/tls/pull/46 hasn't been released to crates.io yet.