### PR TITLE
WIP: Update deps: tokio, hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "0.5"
 native-tls = "0.2"
-hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-tokio = { version = "0.2" }
+hyper = { version = "0.14", default-features = false, features = ["tcp", "client", "http1"] }
+tokio = { version = "1" }
 tokio-tls = "0.3"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["io-std", "macros"] }
+tokio = { version = "1", features = ["io-std", "macros"] }


### PR DESCRIPTION
**This is WIP**

I tried to update the dependencies (tokio, hyper), as tokio 1.0.0 came out tonight.

Unfortunately, it is not as simple as I thought it would be. Can we please work together to update these dependencies?