### PR TITLE
Build project on github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - '**'
 
-
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  style:
+    name: Check Style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: cargo fmt --check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all
+
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose --all -- -D warnings
+
+      - name: cargo doc check
+        uses: actions-rs/cargo@v1
+        with:
+          command: rustdoc
+          args: --all-features -- -D warnings
+
+  test:
+    name: Test ${{ matrix.rust }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Rust (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+  doc:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: rustdoc
+          args: -- --cfg docsrs -D broken-intra-doc-links

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,5 +1,4 @@
-
-use hyper::{Client, body::HttpBody as _};
+use hyper::{body::HttpBody as _, Client};
 use hyper_tls::HttpsConnector;
 use tokio::io::{self, AsyncWriteExt as _};
 
@@ -15,9 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     while let Some(chunk) = res.body_mut().data().await {
         let chunk = chunk?;
-        io::stdout()
-            .write_all(&chunk)
-            .await?
+        io::stdout().write_all(&chunk).await?
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Example
 //!
-//! ```no_run
+//! ```
 //! use hyper_tls::HttpsConnector;
 //! use hyper::Client;
 //!


### PR DESCRIPTION
Copied base structure from `hyperium/hyper`, and modified it to fit `hyper-tls`.
Included a format fix performed with `cargo fmt`, otherwise this workflow would not pass itself.
[![CI](https://github.com/jensim/hyper-tls/workflows/CI/badge.svg?branch=feature%2Fgithub-actions)](https://github.com/jensim/hyper-tls/actions?query=branch%3Afeature%2Fgithub-actions)