### PR TITLE
Support for 'hyper-0.14' and 'tokio-1'  (#76) 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-tls"
-version = "0.4.3" # don't forget html_root_url in lib.rs
+version = "0.5.0" # don't forget html_root_url in lib.rs
 description = "Default TLS implementation for use with hyper"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 license = "MIT/Apache-2.0"
@@ -16,9 +16,9 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "0.5"
 native-tls = "0.2"
-hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-tokio = { version = "0.2" }
-tokio-tls = "0.3"
+hyper = { version = "0.14", default-features = false, features = ["full"] }
+tokio = { version = "1" }
+tokio-native-tls = "0.3"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["io-std", "macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,9 +3,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use hyper::{client::connect::HttpConnector, service::Service, Uri};
+use hyper::{client::HttpConnector, service::Service, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_tls::TlsConnector;
+use tokio_native_tls::TlsConnector;
 
 use crate::stream::MaybeHttpsStream;
 
@@ -65,13 +65,18 @@ impl<T> HttpsConnector<T> {
     pub fn https_only(&mut self, enable: bool) {
         self.force_https = enable;
     }
-    
+
     /// With connector constructor
-    /// 
+    ///
     pub fn new_with_connector(http: T) -> Self {
         native_tls::TlsConnector::new()
             .map(|tls| HttpsConnector::from((http, tls.into())))
-            .unwrap_or_else(|e| panic!("HttpsConnector::new_with_connector(<connector>) failure: {}", e))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "HttpsConnector::new_with_connector(<connector>) failure: {}",
+                    e
+                )
+            })
     }
 }
 
@@ -120,15 +125,17 @@ where
             return err(ForceHttpsButUriNotHttps.into());
         }
 
-        let host = dst.host().unwrap_or("").trim_matches(|c| c == '[' || c == ']').to_owned();
+        let host = dst
+            .host()
+            .unwrap_or("")
+            .trim_matches(|c| c == '[' || c == ']')
+            .to_owned();
         let connecting = self.http.call(dst);
         let tls = self.tls.clone();
         let fut = async move {
             let tcp = connecting.await.map_err(Into::into)?;
             let maybe = if is_https {
-                let tls = tls
-                    .connect(&host, tcp)
-                    .await?;
+                let tls = tls.connect(&host, tcp).await?;
                 MaybeHttpsStream::Https(tls)
             } else {
                 MaybeHttpsStream::Http(tcp)
@@ -143,8 +150,7 @@ fn err<T>(e: BoxError) -> HttpsConnecting<T> {
     HttpsConnecting(Box::pin(async { Err(e) }))
 }
 
-type BoxedFut<T> =
-    Pin<Box<dyn Future<Output = Result<MaybeHttpsStream<T>, BoxError>> + Send>>;
+type BoxedFut<T> = Pin<Box<dyn Future<Output = Result<MaybeHttpsStream<T>, BoxError>> + Send>>;
 
 /// A Future representing work to connect to a URL, and a TLS handshake.
 pub struct HttpsConnecting<T>(BoxedFut<T>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!     Ok(())
 //! }
 //! ```
-#![doc(html_root_url = "https://docs.rs/hyper-tls/0.4.3")]
+#![doc(html_root_url = "https://docs.rs/hyper-tls/0.5.0")]
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
1. Updated the dependencies in `Cargo.toml`.
2. Started using 'tokio-native-tls' as opposed to deprecated 'tokio-tls'
3. Updated implementation of `poll_read` to confirm to new signature as
   per new API.
4. Other Fixes to get build working. (Tested with hyper-0.14.1 and tokio-1.0.1)
6. Updated the version to v0.5.0