### PR TITLE
Implement Support for ALPN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ vendored = ["native-tls/vendored"]
 
 [dependencies]
 bytes = "1"
-native-tls = "0.2.1"
-hyper = { version = "0.14.2", default-features = false, features = ["tcp", "client"] }
+native-tls = { version = "0.2.7", features = ["alpn"] }
+hyper = { version = "0.14.2", default-features = false, features = ["tcp", "client", "http1", "http2"] }
 tokio = "1"
 tokio-native-tls = "0.3"
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -40,7 +40,9 @@ impl HttpsConnector<HttpConnector> {
     /// To handle that error yourself, you can use the `HttpsConnector::from`
     /// constructor after trying to make a `TlsConnector`.
     pub fn new() -> Self {
-        native_tls::TlsConnector::new()
+        native_tls::TlsConnector::builder()
+            .request_alpns(&["h2", "http/1.1"])
+            .build()
             .map(|tls| HttpsConnector::new_(tls.into()))
             .unwrap_or_else(|e| panic!("HttpsConnector::new() failure: {}", e))
     }


### PR DESCRIPTION
This adds support for ALPN via the newly released native-tls 0.2.7. With this hyper-tls can now automatically establish an HTTP2 connection with the server without having to force it from the client side.