### PR TITLE
Update hyper to ^0.14.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "1"
 native-tls = "0.2.1"
-hyper = { version = "0.14.2", default-features = false, features = ["tcp", "client"] }
+hyper = { version = "^0.14.2", default-features = false, features = ["tcp", "client"] }
 tokio = "1"
 tokio-native-tls = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["io-std", "macros", "io-util"] }
-hyper = { version = "0.14.2", default-features = false, features = ["http1"] }
+hyper = { version = "^0.14.2", default-features = false, features = ["http1"] }


### PR DESCRIPTION
This PR allows users to use newer 0.14.x hyper releases. I wasn't entirely sure why the version was pegged to 0.14.2, but looking at the git log, it seems like it was to avoid using earlier 0.14.x versions.