### PR TITLE
feat: upgrade to hyper-v1, use hyper-utils for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,17 @@ vendored = ["native-tls/vendored"]
 [dependencies]
 bytes = "1"
 native-tls = "0.2.1"
-hyper = { version = "0.14.2", default-features = false, features = ["tcp", "client"] }
+hyper = { version = "1.0.0-rc.4", default-features = false }
+hyper-util = { git = "https://github.com/hyperium/hyper-util", default-features = false, features = [
+    "client",
+], rev = "ced9f812460420017705fa7cae4dca7be9e23f4a" }
 tokio = "1"
 tokio-native-tls = "0.3"
+tower-service = "0.3"
+http-body-util = "0.1.0-rc.3"
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["io-std", "macros", "io-util"] }
-hyper = { version = "0.14.2", default-features = false, features = ["http1"] }
+hyper-util = { git = "https://github.com/hyperium/hyper-util", default-features = false, features = [
+    "http1",
+], rev = "ced9f812460420017705fa7cae4dca7be9e23f4a" }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,20 +1,29 @@
-use hyper::{body::HttpBody as _, Client};
+use bytes::Bytes;
+use http_body_util::BodyExt;
+
+use http_body_util::Empty;
 use hyper_tls::HttpsConnector;
+use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use tokio::io::{self, AsyncWriteExt as _};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let https = HttpsConnector::new();
-    let client = Client::builder().build::<_, hyper::Body>(https);
+
+    let client = Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(https);
 
     let mut res = client.get("https://hyper.rs".parse()?).await?;
 
     println!("Status: {}", res.status());
     println!("Headers:\n{:#?}", res.headers());
 
-    while let Some(chunk) = res.body_mut().data().await {
-        let chunk = chunk?;
-        io::stdout().write_all(&chunk).await?
+    while let Some(frame) = res.body_mut().frame().await {
+        let frame = frame?;
+
+        if let Some(d) = frame.data_ref() {
+            io::stdout().write_all(d).await?;
+        }
     }
+
     Ok(())
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,8 +4,12 @@ use std::io::IoSlice;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use hyper::client::connect::{Connected, Connection};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use hyper::rt::{Read, ReadBufCursor, Write};
+
+use hyper_util::{
+    client::connect::{Connected, Connection},
+    rt::TokioIo,
+};
 pub use tokio_native_tls::TlsStream;
 
 /// A stream that might be protected with TLS.
@@ -13,7 +17,7 @@ pub enum MaybeHttpsStream<T> {
     /// A stream over plain text.
     Http(T),
     /// A stream protected with TLS.
-    Https(TlsStream<T>),
+    Https(TokioIo<TlsStream<TokioIo<T>>>),
 }
 
 // ===== impl MaybeHttpsStream =====
@@ -33,18 +37,24 @@ impl<T> From<T> for MaybeHttpsStream<T> {
     }
 }
 
-impl<T> From<TlsStream<T>> for MaybeHttpsStream<T> {
-    fn from(inner: TlsStream<T>) -> Self {
+impl<T> From<TlsStream<TokioIo<T>>> for MaybeHttpsStream<T> {
+    fn from(inner: TlsStream<TokioIo<T>>) -> Self {
+        MaybeHttpsStream::Https(TokioIo::new(inner))
+    }
+}
+
+impl<T> From<TokioIo<TlsStream<TokioIo<T>>>> for MaybeHttpsStream<T> {
+    fn from(inner: TokioIo<TlsStream<TokioIo<T>>>) -> Self {
         MaybeHttpsStream::Https(inner)
     }
 }
 
-impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for MaybeHttpsStream<T> {
+impl<T: Read + Write + Unpin> Read for MaybeHttpsStream<T> {
     #[inline]
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context,
-        buf: &mut ReadBuf,
+        buf: ReadBufCursor<'_>,
     ) -> Poll<Result<(), io::Error>> {
         match Pin::get_mut(self) {
             MaybeHttpsStream::Http(s) => Pin::new(s).poll_read(cx, buf),
@@ -53,7 +63,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for MaybeHttpsStream<T> {
     }
 }
 
-impl<T: AsyncWrite + AsyncRead + Unpin> AsyncWrite for MaybeHttpsStream<T> {
+impl<T: Write + Read + Unpin> Write for MaybeHttpsStream<T> {
     #[inline]
     fn poll_write(
         self: Pin<&mut Self>,
@@ -101,11 +111,13 @@ impl<T: AsyncWrite + AsyncRead + Unpin> AsyncWrite for MaybeHttpsStream<T> {
     }
 }
 
-impl<T: AsyncRead + AsyncWrite + Connection + Unpin> Connection for MaybeHttpsStream<T> {
+impl<T: Connection + Unpin> Connection for MaybeHttpsStream<T> {
     fn connected(&self) -> Connected {
         match self {
             MaybeHttpsStream::Http(s) => s.connected(),
-            MaybeHttpsStream::Https(s) => s.get_ref().get_ref().get_ref().connected(),
+            MaybeHttpsStream::Https(s) => {
+                s.inner().get_ref().get_ref().get_ref().inner().connected()
+            }
         }
     }
 }


### PR DESCRIPTION
Update `hyper-tls` to use `hyper@1.0.0-rc.4`.

I used `hyper-util` for now, because I'm not smart enough to get around that.

I don't like `TokioIo<TlsStream<TokioIo<T>>>`. I think we should lift it to a separate type so it's not as bloated. 

Why did I do this?

I need to use `hyper` (as `reqwest` doesn't do unix sockets yet). And I need TLS (which `hyper` doesn't do OOB).

This seems to do the trick for now.