### PR TITLE
HttpsConnector: add tls_server_name to allow overriding TLS handshake

### DIFF
--- a/examples/client-tls-server-name.rs
+++ b/examples/client-tls-server-name.rs
@@ -1,0 +1,40 @@
+//! HTTPS GET client with custome TLS server name based on hyper-tls
+//!
+//! First parameter is the URL to GET.
+//! Second parameter is the TLS server name to negociate.
+use bytes::Bytes;
+use http_body_util::BodyExt;
+
+use http_body_util::Empty;
+use hyper_tls::HttpsConnector;
+use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+use tokio::io::{self, AsyncWriteExt as _};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+
+    let (Some(url), Some(server_name)) = (args.next(), args.next()) else {
+        println!("Usage: client <url> <server_name>");
+        return Ok(());
+    };
+
+    let https = HttpsConnector::new().with_tls_server_name(server_name);
+
+    let client = Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(https);
+
+    let mut res = client.get(url.parse()?).await?;
+
+    println!("Status:\n{}", res.status());
+    println!("Headers:\n{:#?}", res.headers());
+
+    while let Some(frame) = res.body_mut().frame().await {
+        let frame = frame?;
+
+        if let Some(d) = frame.data_ref() {
+            io::stdout().write_all(d).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ pub struct HttpsConnector<T> {
     force_https: bool,
     http: T,
     tls: TlsConnector,
+    tls_server_name: Option<String>,
 }
 
 impl HttpsConnector<HttpConnector> {
@@ -90,6 +91,15 @@ impl<T> HttpsConnector<T> {
             |tls| HttpsConnector::from((http, tls.into())),
         )
     }
+
+    /// Get a HttpsConnector with a TLS server name override.
+    ///
+    /// This is useful in cases where you can't work around the URL's host but know the name you
+    /// expect from the remote server's certificate.
+    pub fn with_tls_server_name(mut self, server_name: impl Into<String>) -> Self {
+        self.tls_server_name = Some(server_name.into());
+        self
+    }
 }
 
 impl<T> From<(T, TlsConnector)> for HttpsConnector<T> {
@@ -98,6 +108,7 @@ impl<T> From<(T, TlsConnector)> for HttpsConnector<T> {
             force_https: false,
             http: args.0,
             tls: args.1,
+            tls_server_name: None,
         }
     }
 }
@@ -137,8 +148,10 @@ where
             return err(ForceHttpsButUriNotHttps.into());
         }
 
-        let host = dst
-            .host()
+        let host = self
+            .tls_server_name
+            .as_deref()
+            .or_else(|| dst.host())
             .unwrap_or("")
             .trim_matches(|c| c == '[' || c == ']')
             .to_owned();


### PR DESCRIPTION
Hi,

being able to set a TLS server name that's not the same as the request's host is often useful. In particular, when connecting through proxies where you can't use name resolution tricks.

This is my attempt to get this ability here.

Thanks! :)